### PR TITLE
Tombstone messages

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,14 @@
 version: '3.5'
 services:
-  zookeeper-1:
+  test-zookeeper-1:
     image: confluentinc/cp-zookeeper:5.0.0
-    hostname: zookeeper-1
-    container_name: zookeeper-1
+    hostname: test-zookeeper-1
+    container_name: test-zookeeper-1
     ports:
       - "22181:2181"
     environment:
       ZOOKEEPER_SERVER_ID: 1
-      ZOOKEEPER_SERVERS: "zookeeper-1:4182:5181"
+      ZOOKEEPER_SERVERS: "test-zookeeper-1:4182:5181"
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
       ZOOKEEPER_AUTOPURGE_SNAP_RETAIN_COUNT: 3
@@ -19,49 +19,49 @@ services:
       test: /bin/sh -c '[ \"imok\" = \"$$(echo ruok | nc -w 1 127.0.0.1 2181)\" ]' || exit 1
       interval: 1m
     volumes:
-      - zookeeper-1-data:/var/lib/zookeeper/data/
-      - zookeeper-1-log:/var/lib/zookeeper/log/
+      - test-zookeeper-1-data:/var/lib/zookeeper/data/
+      - test-zookeeper-1-log:/var/lib/zookeeper/log/
 
-  kafka-1:
+  test-kafka-1:
     image: confluentinc/cp-kafka:5.0.0
-    hostname: kafka-1
-    container_name: kafka-1
+    hostname: test-kafka-1
+    container_name: test-kafka-1
     stop_grace_period: 5m
     depends_on:
-      - zookeeper-1
+      - test-zookeeper-1
     ports:
       - "9092:9092"
       - "29092:29092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka-1:9092,PLAINTEXT_HOST://localhost:29092"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://test-kafka-1:9092,PLAINTEXT_HOST://localhost:29092"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_NUM_PARTITIONS: 8
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper-1:2181"
+      KAFKA_ZOOKEEPER_CONNECT: "test-zookeeper-1:2181"
       KAFKA_DEFAULT_REPLICATION_FACTOR: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_MIN_INSYNC_REPLICAS: 1
     volumes:
-      - kafka-1-data:/var/lib/kafka/data/
+      - test-kafka-1-data:/var/lib/kafka/data/
 
-  schema-registry:
+  test-schema-registry:
     image: confluentinc/cp-schema-registry:5.0.0
-    hostname: schema-registry
-    container_name: schema-registry
+    hostname: test-schema-registry
+    container_name: test-schema-registry
     depends_on:
-      - zookeeper-1
-      - kafka-1
+      - test-zookeeper-1
+      - test-kafka-1
     ports:
       - "28081:8081"
     environment:
-      SCHEMA_REGISTRY_HOST_NAME: "schema-registry"
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper-1:2181'
+      SCHEMA_REGISTRY_HOST_NAME: "test-schema-registry"
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'test-zookeeper-1:2181'
 
 volumes:
-    zookeeper-1-data:
-    zookeeper-1-log:
-    kafka-1-data:
+    test-zookeeper-1-data:
+    test-zookeeper-1-log:
+    test-kafka-1-data:

--- a/kafkian/producer.py
+++ b/kafkian/producer.py
@@ -58,8 +58,10 @@ class Producer:
         return self._producer_impl.poll(timeout)
 
     def produce(self, topic, key, value, sync=False):
-        value = self.value_serializer.serialize(value, topic)
         key = self.key_serializer.serialize(key, topic, is_key=True)
+        # If value is None, it's a "tombstone" and shall be passed through
+        if value is not None:
+            value = self.value_serializer.serialize(value, topic)
         self._produce(topic, key, value)
         if sync:
             self.flush()

--- a/tests/system/test_produce_consume_avro.py
+++ b/tests/system/test_produce_consume_avro.py
@@ -74,3 +74,13 @@ def test_produce_consume_one(producer, consumer):
     m = next(consumer)
     assert m.key() == key
     assert m.value() == value
+
+
+def test_produce_consume_one_tombstone(producer, consumer):
+    key = str(uuid.uuid4())
+    value = None
+
+    producer.produce(TEST_TOPIC, key, value, sync=True)
+    m = next(consumer)
+    assert m.key() == key
+    assert m.value() == value

--- a/tests/system/test_produce_consume_b.py
+++ b/tests/system/test_produce_consume_b.py
@@ -37,3 +37,12 @@ def test_produce_consume_one(producer, consumer):
     m = next(consumer)
     assert m.key() == key
     assert m.value() == value
+
+
+def test_produce_consume_one_tombstone(producer, consumer):
+    key = bytes(str(uuid.uuid4()), encoding='utf8')
+    value = None
+    producer.produce(TEST_TOPIC, key, value, sync=True)
+    m = next(consumer)
+    assert m.key() == key
+    assert m.value() == value

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -23,9 +23,6 @@ def consumer():
 
 
 class MockMessage(Mock):
-    _key: bytes = None
-    _value: bytes = None
-
     def key(self):
         return self._key
 

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -1,0 +1,53 @@
+import uuid
+from unittest.mock import patch, Mock
+
+import pytest
+
+from kafkian import Consumer
+
+KAFKA_BOOTSTRAP_SERVERS = 'localhost:29092'
+TEST_TOPIC = 'test.test.' + str(uuid.uuid4())
+
+CONSUMER_CONFIG = {
+    'bootstrap.servers': KAFKA_BOOTSTRAP_SERVERS,
+    'default.topic.config': {
+        'auto.offset.reset': 'earliest',
+    },
+    'group.id': str(uuid.uuid4())
+}
+
+
+@pytest.fixture
+def consumer():
+    return Consumer(CONSUMER_CONFIG, [TEST_TOPIC])
+
+
+class MockMessage(Mock):
+    _key: bytes = None
+    _value: bytes = None
+
+    def key(self):
+        return self._key
+
+    def value(self):
+        return self._value
+
+    def set_key(self, new_key):
+        self._key = new_key
+
+    def set_value(self, new_value):
+        self._value = new_value
+
+
+def test_consume_one_tombstone(consumer):
+    key = bytes(str(uuid.uuid4()), encoding='utf8')
+    value = None
+
+    m = MockMessage()
+    m.set_key(key)
+    m.set_value(value)
+
+    with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
+        m = next(consumer)
+    assert m.key() == key
+    assert m.value() == value

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -36,6 +36,20 @@ class MockMessage(Mock):
         self._value = new_value
 
 
+def test_consume_one_b(consumer):
+    key = bytes(str(uuid.uuid4()), encoding='utf8')
+    value = bytes(str(uuid.uuid4()), encoding='utf8')
+
+    m = MockMessage()
+    m.set_key(key)
+    m.set_value(value)
+
+    with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
+        m = next(consumer)
+    assert m.key() == key
+    assert m.value() == value
+
+
 def test_consume_one_tombstone(consumer):
     key = bytes(str(uuid.uuid4()), encoding='utf8')
     value = None

--- a/tests/unit/test_producer_consume_b.py
+++ b/tests/unit/test_producer_consume_b.py
@@ -27,7 +27,7 @@ PRODUCER_CONFIG = {
 
 @pytest.fixture
 def producer():
-    return Producer(CONSUMER_CONFIG)
+    return Producer(PRODUCER_CONFIG)
 
 
 @pytest.fixture
@@ -36,6 +36,9 @@ def consumer():
 
 
 def test_produce_consume_one(producer, consumer):
+    producer_produce_mock.reset_mock()
+    producer_flush_mock.reset_mock()
+
     key = bytes(str(uuid.uuid4()), encoding='utf8')
     value = bytes(str(uuid.uuid4()), encoding='utf8')
     producer.produce(TEST_TOPIC, key, value, sync=True)
@@ -49,3 +52,15 @@ def test_produce_consume_one(producer, consumer):
     # m = next(consumer)
     # assert m.key() == key
     # assert m.value() == value
+
+
+def test_produce_consume_one_tombstone(producer, consumer):
+    producer_produce_mock.reset_mock()
+    producer_flush_mock.reset_mock()
+
+    key = bytes(str(uuid.uuid4()), encoding='utf8')
+    value = None
+    producer.produce(TEST_TOPIC, key, value, sync=True)
+
+    producer_produce_mock.assert_called_once_with(TEST_TOPIC, key, value)
+    producer_flush_mock.assert_called_once_with()


### PR DESCRIPTION
Messages with a non-null key and a null value are so-called "tombstone" messages and used as special markers for deletion when log compaction enabled. Therefore, we shall skip serializing/deserializing such values.
