### PR TITLE
AvroRecord base class for creating producer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,8 @@ producer = Producer(
 #### 2. Define your message schema(s)
 
 ```python
-from avro.schema import Schema
-
-class Message(dict):
-    _schema: Schema = None
+from confluent_kafka import avro
+from kafkian.serde.avroserdebase import AvroRecord
 
 
 value_schema_str = """
@@ -84,7 +82,7 @@ value_schema_str = """
 """
 
 
-class UserCreated(Message):
+class UserCreated(AvroRecord):
     _schema = avro.loads(value_schema_str)
 
 ```

--- a/kafkian/serde/avroserdebase.py
+++ b/kafkian/serde/avroserdebase.py
@@ -21,6 +21,10 @@ class HasSchemaMixin:
         return self._schema
 
 
+class AvroRecord(dict, HasSchemaMixin):
+    pass
+
+
 def _wrap(value, schema):
     """
     Wraps a value into subclass with HasSchemaMixin

--- a/tests/system/test_produce_consume_avro.py
+++ b/tests/system/test_produce_consume_avro.py
@@ -4,6 +4,7 @@ import pytest
 from confluent_kafka import avro
 
 from kafkian import Producer, Consumer
+from kafkian.serde.avroserdebase import AvroRecord
 from kafkian.serde.deserialization import AvroDeserializer
 from kafkian.serde.serialization import AvroStringKeySerializer, AvroSerializer
 
@@ -24,10 +25,6 @@ PRODUCER_CONFIG = {
 }
 
 
-class Message(dict):
-    _schema = None
-
-
 value_schema_str = """
 {
    "namespace": "my.test",
@@ -42,7 +39,9 @@ value_schema_str = """
 }
 """
 
-Message._schema = avro.loads(value_schema_str)
+
+class Message(AvroRecord):
+    _schema = avro.loads(value_schema_str)
 
 
 @pytest.fixture

--- a/tests/unit/test_producer_avro.py
+++ b/tests/unit/test_producer_avro.py
@@ -5,6 +5,7 @@ import pytest
 from confluent_kafka import avro
 
 from kafkian import producer
+from kafkian.serde.avroserdebase import AvroRecord
 from kafkian.serde.serialization import AvroSerializer, Serializer
 from tests.unit.conftest import producer_produce_mock
 
@@ -17,14 +18,6 @@ PRODUCER_CONFIG = {
     'schema.registry.url': SCHEMA_REGISTRY_URL,
 }
 
-
-class Message(dict):
-    _schema = None
-
-
-message = Message({
-    'name': 'some name'
-})
 
 value_schema_str = """
 {
@@ -40,7 +33,14 @@ value_schema_str = """
 }
 """
 
-message._schema = avro.loads(value_schema_str)
+
+class Message(AvroRecord):
+    _schema = avro.loads(value_schema_str)
+
+
+message = Message({
+    'name': 'some name'
+})
 
 
 def teardown_function(function):


### PR DESCRIPTION
`AvroBase` class is a subclass of `dict` and a schema mixin. It's expected to be used like that:

```
value_schema_str = """
{
   "namespace": "my.test",
   "name": "SomeEvent",
   "type": "record",
   "fields" : [
     {
       "name" : "name",
       "type" : "string"
     }
   ]
}
"""


class SomeEvent(AvroRecord):
    _schema = avro.loads(value_schema_str)


event = SomeEvent({
    'name': 'some name'
})

producer.produce(key, event, topic)
```