### PR TITLE
Consumer exception handling

### DIFF
--- a/kafkian/__init__.py
+++ b/kafkian/__init__.py
@@ -1,4 +1,5 @@
 from .consumer import Consumer
 from .producer import Producer
+from .exceptions import KafkianException
 
-__all__ = ['Consumer', 'Producer']
+__all__ = ['Consumer', 'Producer', 'KafkianException']

--- a/kafkian/consumer.py
+++ b/kafkian/consumer.py
@@ -1,11 +1,12 @@
+import atexit
 import socket
 import typing
 from typing import Callable
 
 import structlog
 from confluent_kafka.cimpl import Consumer as ConfluentConsumer, KafkaError
-from confluent_kafka.cimpl import KafkaException
 
+from kafkian.exceptions import KafkianException
 from kafkian.serde.deserialization import Deserializer
 
 logger = structlog.get_logger(__name__)
@@ -31,7 +32,7 @@ class Consumer:
     def __init__(
         self, config: typing.Dict, topics: typing.Iterable,
             value_deserializer=Deserializer(), key_deserializer=Deserializer(),
-            error_handler: Callable = None
+            error_callbacks: typing.List[Callable] = None
     ) -> None:
         self._subscribed = False
         self.topics = list(topics)
@@ -42,6 +43,8 @@ class Consumer:
         logger.info("Initializing consumer", config=config)
         self._consumer_impl = self._init_consumer_impl(config)
         self._generator = self._message_generator()
+        self.error_callbacks = error_callbacks
+        atexit.register(self._close)
 
     @staticmethod
     def _init_consumer_impl(config):
@@ -54,29 +57,37 @@ class Consumer:
         self._subscribed = True
 
     def __iter__(self):
+        self._subscribe()
         return self
 
     def __next__(self):
         self._subscribe()
         try:
             return next(self._generator)
-        except KafkaException:
-            raise StopIteration
+        except:
+            self._close()
+            raise
 
     def __enter__(self):
         self._consumer_impl.subscribe(self.topics)
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
-        # the only reason a consumer exits is when an
-        # exception is raised.
-        #
-        # close down the consumer cleanly accordingly:
-        #  - stops consuming
-        #  - commit offsets (only on auto commit)
-        #  - leave consumer group
+        self._close()
+
+    def _close(self):
+        """
+        Close down the consumer cleanly accordingly:
+         - stops consuming
+         - commit offsets (only on auto commit)
+         - leave consumer group
+        """
         logger.info("Closing consumer")
-        self._consumer_impl.close()
+        try:
+            self._consumer_impl.close()
+        except RuntimeError:
+            # Consumer is probably already closed
+            pass
 
     def _poll(self):
         return self._consumer_impl.poll(timeout=self.timeout)
@@ -88,8 +99,11 @@ class Consumer:
                 if self.non_blocking:
                     yield None
                 continue
-            if message.error() == KafkaError._PARTITION_EOF:
-                continue
+            if message.error():
+                if message.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                self._on_poll_error(message)
+                raise KafkianException(message.error())
             yield self._deserialize(message)
 
     def _deserialize(self, message):
@@ -102,4 +116,13 @@ class Consumer:
         return message
 
     def commit(self, sync=False):
+        """
+        Commits current consumer offsets.
+        :param sync: do a synchronous commit (false by default)
+        """
         self._consumer_impl.commit(asynchronous=not sync)
+
+    def _on_poll_error(self, message):
+        if self.error_callbacks:
+            for cb in self.error_callbacks:
+                cb(message)

--- a/kafkian/consumer.py
+++ b/kafkian/consumer.py
@@ -31,8 +31,7 @@ class Consumer:
 
     def __init__(
         self, config: typing.Dict, topics: typing.Iterable,
-            value_deserializer=Deserializer(), key_deserializer=Deserializer(),
-            error_callbacks: typing.List[Callable] = None
+            value_deserializer=Deserializer(), key_deserializer=Deserializer()
     ) -> None:
         self._subscribed = False
         self.topics = list(topics)
@@ -43,7 +42,6 @@ class Consumer:
         logger.info("Initializing consumer", config=config)
         self._consumer_impl = self._init_consumer_impl(config)
         self._generator = self._message_generator()
-        self.error_callbacks = error_callbacks
         atexit.register(self._close)
 
     @staticmethod
@@ -102,7 +100,6 @@ class Consumer:
             if message.error():
                 if message.error().code() == KafkaError._PARTITION_EOF:
                     continue
-                self._on_poll_error(message)
                 raise KafkianException(message.error())
             yield self._deserialize(message)
 
@@ -121,8 +118,3 @@ class Consumer:
         :param sync: do a synchronous commit (false by default)
         """
         self._consumer_impl.commit(asynchronous=not sync)
-
-    def _on_poll_error(self, message):
-        if self.error_callbacks:
-            for cb in self.error_callbacks:
-                cb(message)

--- a/kafkian/exceptions.py
+++ b/kafkian/exceptions.py
@@ -1,0 +1,2 @@
+class KafkianException(Exception):
+    pass

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, Mock
 producer_produce_mock = Mock()
 producer_poll_mock = Mock(return_value=1)
 producer_flush_mock = Mock()
+consumer_close_mock = Mock()
 
 mocks = [
     # patch('datadog.statsd', Mock()),
@@ -10,8 +11,8 @@ mocks = [
     patch('kafkian.Producer._produce', producer_produce_mock),
     patch('kafkian.Producer.poll', producer_poll_mock),
     patch('kafkian.Producer.flush', producer_flush_mock),
-
     patch('kafkian.consumer.Consumer._init_consumer_impl', Mock(return_value=Mock())),
+    patch('kafkian.consumer.Consumer._close', consumer_close_mock),
 ]
 
 for mock in mocks:

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -35,6 +35,9 @@ class MockMessage(Mock):
     def set_value(self, new_value):
         self._value = new_value
 
+    def error(self):
+        return None
+
 
 def test_consume_one_b(consumer):
     key = bytes(str(uuid.uuid4()), encoding='utf8')

--- a/tests/unit/test_consumer_avro.py
+++ b/tests/unit/test_consumer_avro.py
@@ -69,6 +69,9 @@ class MockMessage(Mock):
     def set_value(self, new_value):
         self._value = new_value
 
+    def error(self):
+        return None
+
 
 @patch(
     'confluent_kafka.avro.CachedSchemaRegistryClient.register',

--- a/tests/unit/test_consumer_errors.py
+++ b/tests/unit/test_consumer_errors.py
@@ -1,0 +1,86 @@
+import uuid
+from unittest.mock import patch, Mock
+
+import pytest
+from confluent_kafka.cimpl import KafkaError
+
+from tests.unit.conftest import consumer_close_mock
+from kafkian.consumer import Consumer, KafkianException
+
+KAFKA_BOOTSTRAP_SERVERS = 'localhost:29092'
+TEST_TOPIC = 'test.test.' + str(uuid.uuid4())
+
+CONSUMER_CONFIG = {
+    'bootstrap.servers': KAFKA_BOOTSTRAP_SERVERS,
+    'default.topic.config': {
+        'auto.offset.reset': 'earliest',
+    },
+    'group.id': str(uuid.uuid4())
+}
+
+
+@pytest.fixture
+def consumer():
+    return Consumer(CONSUMER_CONFIG, [TEST_TOPIC])
+
+
+class MockMessage:
+    def __init__(self, _key, _value, _error):
+        self._key = _key
+        self._value = _value
+        self._error = _error
+
+    def key(self):
+        return self._key
+
+    def value(self):
+        return self._value
+
+    def set_key(self, new_key):
+        self._key = new_key
+
+    def set_value(self, new_value):
+        self._value = new_value
+
+    def error(self):
+        return self._error
+
+
+class MockError:
+    def __init__(self, _code):
+        self._code = _code
+
+    def code(self):
+        return self._code
+
+
+def test_consumer_ignores_partition_eof(consumer):
+    key = bytes(str(uuid.uuid4()), encoding='utf8')
+    value = bytes(str(uuid.uuid4()), encoding='utf8')
+
+    # The first message with _PARTITION_EOF error, should be skipped
+    m1 = MockMessage(None, None, _error=MockError(_code=KafkaError._PARTITION_EOF))
+    # The next one should be delivered
+    m2 = MockMessage(key, value, _error=None)
+
+    messages = iter([m1, m2])
+
+    def next_message(ignored):
+        return next(messages)
+
+    with patch('kafkian.consumer.Consumer._poll', next_message):
+        m = next(consumer)
+    assert m.key() == key
+    assert m.value() == value
+
+
+def test_consumer_generator_raises_and_closed_on_error(consumer):
+    m = MockMessage(None, None, _error=MockError(_code=-1))
+
+    with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
+        try:
+            next(consumer)
+        except Exception as e:
+            assert isinstance(e, KafkianException)
+
+        consumer_close_mock.assert_called_once_with()


### PR DESCRIPTION
Better error handling in consumer:
 
 - continue in case of _PARTITION_EOF
 - raise an exception with code from KafkaError otherwise
 - gracefully close consumer on exception/process exit.
