### PR TITLE
Lazy deserialization of consumed message key and value

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,21 @@ for message in consumer:
     consumer.commit()
 ```
 
-Here, `message` is an instance of `Message` class exposed by the 
-confluent-kafka-python, access the decoded key and value via `.key()` 
-and `.value()` respectively.
+Here, `message` is an instance of `Message` class, that wraps the original 
+message exposed by the confluent-kafka-python, and you can access 
+the decoded key and value via `.key` and `.value` properties respectively.
+
+Notice that deserialization will happen on first access of the properties,
+so you can properly handle deserialization errors (log it, send to DLQ, etc)
 
 Both key and value are wrapped in a dynamically-generated class,
 that has the full name same as the corresponding Avro schema full name.
 In the example above, the value would have class named `auth.users.UserCreated`.
 
 Avro schemas for the consumed message key and value are accessible via `.schema` property.
+
+In addition, `topic`, `partition`, `offset`, `timestamp`, `headers` properties
+are available.
 
 ## Contributing
 This library is, as stated, quite opinionated, however, I'm open to suggestions.

--- a/kafkian/message.py
+++ b/kafkian/message.py
@@ -1,0 +1,53 @@
+from confluent_kafka.cimpl import Message as ConfluentKafkaMessage
+
+from kafkian.serde.deserialization import Deserializer
+
+
+class Message:
+    def __init__(self, 
+                 message: ConfluentKafkaMessage, 
+                 key_deserializer: Deserializer,
+                 value_deserializer: Deserializer):
+        self._message = message
+        self._key_deserializer = key_deserializer
+        self._value_deserializer = value_deserializer
+        self._deserialized_key = None
+        self._deserialized_value = None
+    
+    @property
+    def key(self):
+        if self._deserialized_key:
+            return self._deserialized_key
+        if self._message.key() is None:
+            return None
+        self._deserialized_key = self._key_deserializer.deserialize(self._message.key())
+        return self._deserialized_key
+    
+    @property
+    def value(self):
+        if self._deserialized_value:
+            return self._deserialized_value
+        if self._message.value() is None:
+            return None
+        self._deserialized_value = self._value_deserializer.deserialize(self._message.value())
+        return self._deserialized_value
+
+    @property
+    def topic(self):
+        return self._message.topic()
+
+    @property
+    def partition(self):
+        return self._message.partition()
+
+    @property
+    def offset(self):
+        return self._message.offset()
+
+    @property
+    def timestamp(self):
+        return self._message.timestamp()
+
+    @property
+    def headers(self):
+        return self._message.headers()

--- a/kafkian/message.py
+++ b/kafkian/message.py
@@ -1,9 +1,22 @@
-from confluent_kafka.cimpl import Message as ConfluentKafkaMessage
+from typing import Optional
+
+from confluent_kafka.cimpl import Message as ConfluentKafkaMessage, TIMESTAMP_NOT_AVAILABLE
 
 from kafkian.serde.deserialization import Deserializer
 
 
 class Message:
+    """
+    Message is an object (log record) consumed from Kafka.
+
+    It provides read-only access to key, value, and message metadata:
+    topic, partition, offset, and optionally timestamp and headers.
+
+    Key and value and deserialized on first access.
+
+    This class wraps cimpl.Message from confluent_kafka
+    and not supposed to be user-instantiated.
+    """
     def __init__(self, 
                  message: ConfluentKafkaMessage, 
                  key_deserializer: Deserializer,
@@ -16,6 +29,9 @@ class Message:
     
     @property
     def key(self):
+        """
+        :return: Deserialized message key
+        """
         if self._deserialized_key:
             return self._deserialized_key
         if self._message.key() is None:
@@ -25,6 +41,9 @@ class Message:
     
     @property
     def value(self):
+        """
+        :return: Deserialized message value
+        """
         if self._deserialized_value:
             return self._deserialized_value
         if self._message.value() is None:
@@ -33,21 +52,50 @@ class Message:
         return self._deserialized_value
 
     @property
-    def topic(self):
+    def topic(self) -> str:
+        """
+        :return: Message topic
+        """
         return self._message.topic()
 
     @property
-    def partition(self):
+    def partition(self) -> int:
+        """
+        :return: Message partition
+        """
         return self._message.partition()
 
     @property
-    def offset(self):
+    def offset(self) -> int:
+        """
+        :return: Message offset
+        """
         return self._message.offset()
 
     @property
-    def timestamp(self):
-        return self._message.timestamp()
+    def timestamp(self) -> Optional[int]:
+        """
+        :return: Message timestamp, of None if not available.
+        """
+        if not self._message.timestamp():
+            return None
+        if self._message.timestamp()[0] == TIMESTAMP_NOT_AVAILABLE:
+            return None
+        return self._message.timestamp()[1]
 
     @property
-    def headers(self):
-        return self._message.headers()
+    def timestamp_type(self) -> Optional[int]:
+        """
+        :return: Message timestamp type - either message creation time or Log Append time, of None if not available.
+        """
+        if not self._message.timestamp():
+            return None
+        return self._message.timestamp()[0]
+
+    @property
+    def headers(self) -> list:
+        """
+        :return: Message headers as list of two-tuples, one (key, value) pair for each header.
+        :rtype: [(str, bytes),...] or None.
+        """
+        return self._message.headers() or []

--- a/tests/system/test_produce_consume_avro.py
+++ b/tests/system/test_produce_consume_avro.py
@@ -71,8 +71,8 @@ def test_produce_consume_one(producer, consumer):
     with consumer:
         m = next(consumer)
         consumer.commit(sync=True)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value
 
 
 def test_produce_consume_one_tombstone(producer, consumer):
@@ -83,5 +83,5 @@ def test_produce_consume_one_tombstone(producer, consumer):
     with consumer:
         m = next(consumer)
         consumer.commit(sync=True)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value

--- a/tests/system/test_produce_consume_b.py
+++ b/tests/system/test_produce_consume_b.py
@@ -35,8 +35,8 @@ def test_produce_consume_one(producer, consumer):
     with consumer:
         m = next(consumer)
         consumer.commit(sync=True)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value
 
 
 def test_produce_consume_one_tombstone(producer, consumer):
@@ -46,5 +46,5 @@ def test_produce_consume_one_tombstone(producer, consumer):
     with consumer:
         m = next(consumer)
         consumer.commit(sync=True)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value

--- a/tests/system/test_produce_consume_commit_offset.py
+++ b/tests/system/test_produce_consume_commit_offset.py
@@ -37,8 +37,8 @@ def test_produce_many_consume_one(producer, consumer):
     with consumer:
         m = next(consumer)
         committed_offsets = consumer.commit(sync=True)
-        committed = list(filter(lambda tp: tp.partition == m.partition() and tp.topic == m.topic(), committed_offsets))[0]
-        assert committed.offset == m.offset() + 1
+        committed = list(filter(lambda tp: tp.partition == m.partition and tp.topic == m.topic, committed_offsets))[0]
+        assert committed.offset == m.offset + 1
 
 
 def test_produce_many_consume_some(producer, consumer):
@@ -51,5 +51,5 @@ def test_produce_many_consume_some(producer, consumer):
         for _ in range(len(values) // 2):
             m = next(consumer)
         committed_offsets = consumer.commit(sync=True)
-        committed = list(filter(lambda tp: tp.partition == m.partition() and tp.topic == m.topic(), committed_offsets))[0]
-        assert committed.offset == m.offset() + 1
+        committed = list(filter(lambda tp: tp.partition == m.partition and tp.topic == m.topic, committed_offsets))[0]
+        assert committed.offset == m.offset + 1

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -47,8 +47,8 @@ def test_consume_one_b(consumer):
 
     with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
         m = next(consumer)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value
 
 
 def test_consume_one_tombstone(consumer):
@@ -61,5 +61,5 @@ def test_consume_one_tombstone(consumer):
 
     with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
         m = next(consumer)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value

--- a/tests/unit/test_consumer_avro.py
+++ b/tests/unit/test_consumer_avro.py
@@ -93,8 +93,8 @@ def test_consume_one_avro_value(consumer):
 
     with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
         received = next(consumer)
-    assert received.key() == key
-    assert received.value() == value
+    assert received.key == key
+    assert received.value == value
 
 
 def test_consume_one_tombstone(consumer):
@@ -107,5 +107,5 @@ def test_consume_one_tombstone(consumer):
 
     with patch('kafkian.consumer.Consumer._poll', Mock(return_value=m)):
         m = next(consumer)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value

--- a/tests/unit/test_consumer_errors.py
+++ b/tests/unit/test_consumer_errors.py
@@ -68,8 +68,8 @@ def test_consumer_ignores_partition_eof(consumer):
 
     with patch('kafkian.consumer.Consumer._poll', next_message):
         m = next(consumer)
-    assert m.key() == key
-    assert m.value() == value
+    assert m.key == key
+    assert m.value == value
 
 
 def test_consumer_generator_raises_and_closed_on_error(consumer):

--- a/tests/unit/test_producer_consume_b.py
+++ b/tests/unit/test_producer_consume_b.py
@@ -48,8 +48,8 @@ def test_produce_consume_one(producer, consumer):
     # # producer.flush()
     # # producer.poll()
     # m = next(consumer)
-    # assert m.key() == key
-    # assert m.value() == value
+    # assert m.key == key
+    # assert m.value == value
 
 
 def test_produce_consume_one_tombstone(producer, consumer):


### PR DESCRIPTION
Wrap `Message` in a pure Python class, that does key and value deserialization in a lazy way and caches the deserialization results. With this, we
 * have much better control when message key or value fails to deserialize for any reason,
 * can skip certain messages without deserializing them,
 * can easier mock/whatever in tests.